### PR TITLE
Fix zconf.h on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(GamePlay-deps)
 
 IF(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ANDROID)
     SET(LINUX 1)
-ENDIF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+ENDIF(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT ANDROID)
 
 if(NOT ANDROID AND NOT IOS)
     # Skip any introspection for cross-compiling targets

--- a/zlib-1.2.8/zconf.h.cmakein.original
+++ b/zlib-1.2.8/zconf.h.cmakein.original
@@ -8,9 +8,7 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 #cmakedefine Z_PREFIX
-#ifndef _WIN32
 #cmakedefine Z_HAVE_UNISTD_H
-#endif
 
 /*
  * If you *really* need a unique prefix for all types and library functions,


### PR DESCRIPTION
We use a unified include directory tree for all platforms.  This leads to
some issues with autoconf style headers (like zconf.h).  In this case
Unix-based systems have unistd.h, and I need to exclude that for Windows.

Also fixed an unmatched if/endif in CMakeLists.txt